### PR TITLE
Adding parameters so old files can be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,7 @@ To use the lambda function to deploy your built website to your website's S3 buc
 * Provider: AWS Lambda
 * Function name: ```<Name of your Lambda Function>```
 * User parameters: ```<Name of your S3 bucket>```
+    * You may also optionally add ```,true``` to have the lambda remove files from the target bucket that aren't found in the artifact package.
+    * On top of that, you can optionally add a pipe (```|```) separated list of files to exclude from this logic, such as environment-specific script or resource files. 
+    * Full usage example: ```mysite-com-live,true,robots.txt```
 * Input artifacts #1: ```<output artifact from your build step>```

--- a/src/website.ts
+++ b/src/website.ts
@@ -38,4 +38,45 @@ export class Website {
                 });
             });
     }
+
+    async removeDifferences(keepFiles: string[]) : Promise<AWS.S3.Error[]> {
+        let existingFiles = await this.getAWSBucketListing();
+
+        let filesToRemove = existingFiles.filter((item) => { return ! (keepFiles.indexOf(item) > -1); });
+
+        if (filesToRemove.length !== 0) {
+            console.log("Deleting old files: " + JSON.stringify(filesToRemove));
+            let params = {
+                Bucket: this.bucketName,
+                Delete: {
+                    Objects: filesToRemove.map((item) => ({ Key: item }))
+                }
+            };
+            let result = await this.s3.deleteObjects(params).promise();
+            return result.Errors || [];
+        }
+        return [];
+    }
+
+    private async getAWSBucketListing(): Promise<string[]> {
+        let params: any = { Bucket: this.bucketName };
+        let files: string[] = [];
+        let keepGoing = true;
+
+        while (keepGoing) {
+            let response = await this.s3.listObjectsV2(params).promise();
+            
+            (response.Contents || [])
+                .map((item) => { return item.Key || ""; })
+                .forEach((item) => { files.push(item); });
+
+            if (response.IsTruncated) {
+                params.ContinuationToken = response.NextContinuationToken;
+            } else {
+                keepGoing = false;
+            }
+        }
+
+        return files;
+    }
 }


### PR DESCRIPTION
Example: removing an old blog post, author page, outdated content. 

This addition allows the user to optionally provide additional arguments to the User Parameters field.
The first argument is still the bucket name. 
The second is now a flag that will enable "remove unknown files" functionality. 
The third is a whitelist that prevents the previous functionality from removing files that are environment specific, and should remain in the bucket no matter what. 