### PR TITLE
Add optional key prefix (i.e. bucket directory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The lambda function will need a policy that permits access to your website's S3 
             "Effect": "Allow",
             "Action": "s3:*",
             "Resource": [
+                "arn:aws:s3:::example.com",
                 "arn:aws:s3:::example.com/*"
             ]
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ class UserParameters {
     targetS3Bucket: string;
     cleanAbsentFiles: boolean;
     ignoreFiles: string[];
+    keyPrefix: string;
 }
 
 class EventHandler {
@@ -70,6 +71,9 @@ class EventHandler {
                 .on("entry", (entry: any) => {
                     let fileName = this.stripLeadingPathChars(entry.path);
 
+                    if (this.userParameters.keyPrefix)
+                      fileName = this.userParameters.keyPrefix + fileName;
+
                     this.website.uploadFileFromStream(fileName, entry);
                     files.push(fileName);
                 })
@@ -81,7 +85,7 @@ class EventHandler {
                     reject(err);
                 });
         });
-        
+
         return await unzipPromise;
     }
 
@@ -133,6 +137,9 @@ class EventHandler {
         }
         if (params.length > 2) {
             userParameters.ignoreFiles = params[2].split('|');
+        }
+        if (params.length > 3) {
+        	userParameters.keyPrefix = params[3];
         }
         return userParameters;
     }


### PR DESCRIPTION
I have a need for a number of AWS Code Builds/CodePipelines using a single s3 bucket, but each builds artifacts going into its own sub-directory of that bucket.  As such, I've added an extra parameter to allow a key prefix (==bucket directory).
