### PR TITLE
Bucket sub-folder changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The lambda function will need a policy that permits access to your website's S3 
             "Effect": "Allow",
             "Action": "s3:*",
             "Resource": [
+                "arn:aws:s3:::example.com",
                 "arn:aws:s3:::example.com/*"
             ]
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ class UserParameters {
     targetS3Bucket: string;
     cleanAbsentFiles: boolean;
     ignoreFiles: string[];
+    keyPrefix: string;
 }
 
 class EventHandler {
@@ -70,6 +71,9 @@ class EventHandler {
                 .on("entry", (entry: any) => {
                     let fileName = this.stripLeadingPathChars(entry.path);
 
+                    if (this.userParameters.keyPrefix)
+                      fileName = this.userParameters.keyPrefix + fileName;
+
                     this.website.uploadFileFromStream(fileName, entry);
                     files.push(fileName);
                 })
@@ -81,7 +85,7 @@ class EventHandler {
                     reject(err);
                 });
         });
-        
+
         return await unzipPromise;
     }
 
@@ -133,6 +137,9 @@ class EventHandler {
         }
         if (params.length > 2) {
             userParameters.ignoreFiles = params[2].split('|');
+        }
+        if (params.length > 3) {
+        	userParameters.keyPrefix = params[3];
         }
         return userParameters;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ class EventHandler {
     }
 
     private createWebsite(): Website {
-        return new Website(this.userParameters.targetS3Bucket, (message, err) => {
+        return new Website(this.userParameters.targetS3Bucket, this.userParameters.keyPrefix, (message, err) => {
             this.failJob(message, err);
         });
     }

--- a/src/website.ts
+++ b/src/website.ts
@@ -8,7 +8,7 @@ export interface IErrorHandler {
 export class Website {
     private s3: AWS.S3;
 
-    constructor(private bucketName: string, private onError: IErrorHandler) {
+    constructor(private bucketName: string, private keyPrefix: string, private onError: IErrorHandler) {
         this.s3 = new AWS.S3({ apiVersion: '2006-03-01' });
     }
 
@@ -59,7 +59,7 @@ export class Website {
     }
 
     private async getAWSBucketListing(): Promise<string[]> {
-        let params: any = { Bucket: this.bucketName };
+        let params: any = { Bucket: this.bucketName, Prefix: this.keyPrefix };
         let files: string[] = [];
         let keepGoing = true;
 


### PR DESCRIPTION
Allow (optional) specification of a key prefix (i.e. bucket sub-folder)
Add missing "listObjectsV2" permissions to Readme.md
Fix to include key prefix in cleanup process