### PR TITLE
Add default property values for UserParameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,10 @@ interface ICallbackFn {
 }
 
 class UserParameters {
-    targetS3Bucket: string;
-    cleanAbsentFiles: boolean;
-    ignoreFiles: string[];
-    keyPrefix: string;
+    targetS3Bucket: string = '';
+    cleanAbsentFiles: boolean = false;
+    ignoreFiles: string[] = [];
+    keyPrefix: string = '';
 }
 
 class EventHandler {


### PR DESCRIPTION
So that it works with TypeScript 2.7's strict class initialization.

Without this, it errors like this:
```
src/index.ts(12,5): error TS2564: Property 'targetS3Bucket' has no initializer and is not definitely assigned in the constructor.
src/index.ts(13,5): error TS2564: Property 'cleanAbsentFiles' has no initializer and is not definitely assigned in the constructor.
src/index.ts(14,5): error TS2564: Property 'ignoreFiles' has no initializer and is not definitely assigned in the constructor.
src/index.ts(15,5): error TS2564: Property 'keyPrefix' has no initializer and is not definitely assigned in the constructor.
npm ERR! code ELIFECYCLE                                                                                           
npm ERR! errno 2                                                                                                   
npm ERR! lambda-deploy-codepipeline-artifact-to-s3-website@1.0.3 build: `tsc && gulp install && gulp build:zip`                 
npm ERR! Exit status 2                                   
npm ERR!                                       
npm ERR! Failed at the lambda-deploy-codepipeline-artifact-to-s3-website@1.0.3 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.                 
```